### PR TITLE
Changing the activation function for final layer

### DIFF
--- a/16_cnn_cifar10_small_image_classification/cnn_cifar10_dataset.ipynb
+++ b/16_cnn_cifar10_small_image_classification/cnn_cifar10_dataset.ipynb
@@ -315,7 +315,7 @@
     "        layers.Flatten(input_shape=(32,32,3)),\n",
     "        layers.Dense(3000, activation='relu'),\n",
     "        layers.Dense(1000, activation='relu'),\n",
-    "        layers.Dense(10, activation='sigmoid')    \n",
+    "        layers.Dense(10, activation='softmax')    \n",
     "    ])\n",
     "\n",
     "ann.compile(optimizer='SGD',\n",
@@ -664,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since it is a multiclass classification, softmax seems to be a more appropriate choice for the selection of activation function for the final layer.